### PR TITLE
build: install prefix to ICON_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ install(TARGETS wallpaperengine-gui
 )
 
 # Desktop file
-set(ICON_INSTALL_DIR "share/pixmaps")
+set(ICON_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/pixmaps")
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/desktop/wallpaperengine-gui.desktop.in
     ${CMAKE_CURRENT_BINARY_DIR}/wallpaperengine-gui.desktop


### PR DESCRIPTION
Added CMAKE_INSTALL_PREFIX to ICON_INSTALL_DIR so the desktop files doesn't break when installing using a custom prefix by running sum like `cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..` (which is the case for an AUR package for example).
I've tried and it works with both the regular manual installation (without prefix) and with prefix